### PR TITLE
Use language-docker 10.0.0

### DIFF
--- a/dockerfile-creator.cabal
+++ b/dockerfile-creator.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 301ffca16b19023e556f9590e046688e1b2da2f00506cf1f5f353972eb71ff45
+-- hash: e403acf210ecbf55cebdeb26a3a034b39f996870b50bea93f0817c81734ee71e
 
 name:           dockerfile-creator
 version:        0.1.0.0
@@ -40,7 +40,7 @@ library
     , bytestring >=0.10
     , data-default-class
     , free
-    , language-docker >=8.1
+    , language-docker >=10.0.0
     , megaparsec >=8.0
     , mtl
     , template-haskell
@@ -71,7 +71,7 @@ test-suite dockerfile-composer-test
     , filepath
     , free
     , hspec
-    , language-docker >=8.1
+    , language-docker >=10.0.0
     , megaparsec >=8.0
     , mtl
     , process

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ description: Embedded DSL to create Dockerfiles using Haskell.
 dependencies:
 - base >= 4.7 && < 5
 - bytestring >=0.10
-- language-docker >= 8.1
+- language-docker >= 10.0.0
 - free
 - mtl
 - template-haskell

--- a/src/Language/Docker/EDSL.hs
+++ b/src/Language/Docker/EDSL.hs
@@ -55,11 +55,11 @@ runD :: MonadWriter [Syntax.Instruction Text] m => EInstruction (m b) -> m b
 runD (From (EBaseImage name t d a p) n) = runDef Syntax.From (Syntax.BaseImage name t d a p) n
 runD (CmdArgs as n) = runDef Syntax.Cmd as n
 runD (Shell as n) = runDef Syntax.Shell as n
-runD (AddArgs s d c n) = runDef Syntax.Add (Syntax.AddArgs s d c) n
+runD (AddArgs s d co cm n) = runDef Syntax.Add (Syntax.AddArgs s d co cm) n
 runD (User u n) = runDef Syntax.User u n
 runD (Label ps n) = runDef Syntax.Label ps n
 runD (StopSignal s n) = runDef Syntax.Stopsignal s n
-runD (CopyArgs s d c f n) = runDef Syntax.Copy (Syntax.CopyArgs s d c f) n
+runD (CopyArgs s d co cm f n) = runDef Syntax.Copy (Syntax.CopyArgs s d co cm f) n
 runD (RunArgs as fs n) = runDef Syntax.Run (Syntax.RunArgs as fs) n
 runD (Workdir d n) = runDef Syntax.Workdir d n
 runD (Expose ps n) = runDef Syntax.Expose ps n
@@ -210,7 +210,7 @@ cmd = cmdArgs
 -- copy $ ["some_file"] `to` "/some/path" `fromStage` "builder"
 -- @
 copy :: MonadFree EInstruction m => Syntax.CopyArgs -> m ()
-copy (Syntax.CopyArgs sources dest ch src) = copyArgs sources dest ch src
+copy (Syntax.CopyArgs sources dest co cm src) = copyArgs sources dest co cm src
 
 -- | Create a COPY instruction from a given build stage.
 -- This is a shorthand version of using 'copy' with combinators.
@@ -224,7 +224,7 @@ copyFromStage ::
   NonEmpty Syntax.SourcePath ->
   Syntax.TargetPath ->
   m ()
-copyFromStage stage source dest = copy $ Syntax.CopyArgs source dest Syntax.NoChown stage
+copyFromStage stage source dest = copy $ Syntax.CopyArgs source dest Syntax.NoChown Syntax.NoChmod stage
 
 -- | Create an ADD instruction. This is often used as a shorthand version
 -- of copy when no extra options are needed. Currently there is no way to
@@ -234,7 +234,7 @@ copyFromStage stage source dest = copy $ Syntax.CopyArgs source dest Syntax.NoCh
 -- add ["foo.js", "bar.js"] "."
 -- @
 add :: MonadFree EInstruction m => NonEmpty Syntax.SourcePath -> Syntax.TargetPath -> m ()
-add sources dest = addArgs sources dest Syntax.NoChown
+add sources dest = addArgs sources dest Syntax.NoChown Syntax.NoChmod
 
 -- | Converts a NonEmpty list of strings to a NonEmpty list of 'Syntax.SourcePath'
 --
@@ -288,7 +288,7 @@ ownedBy args owner = args {Syntax.chownFlag = owner}
 -- copy $ ["foo.js"] `to` "." `ownedBy`
 -- @
 to :: NonEmpty Syntax.SourcePath -> Syntax.TargetPath -> Syntax.CopyArgs
-to sources dest = Syntax.CopyArgs sources dest Syntax.NoChown Syntax.NoSource
+to sources dest = Syntax.CopyArgs sources dest Syntax.NoChown Syntax.NoChmod Syntax.NoSource
 
 ports :: [Syntax.Port] -> Syntax.Ports
 ports = Syntax.Ports

--- a/src/Language/Docker/EDSL/Types.hs
+++ b/src/Language/Docker/EDSL/Types.hs
@@ -27,6 +27,7 @@ data EInstruction next
       (NonEmpty Syntax.SourcePath)
       Syntax.TargetPath
       Syntax.Chown
+      Syntax.Chmod
       next
   | User
       Text
@@ -41,6 +42,7 @@ data EInstruction next
       (NonEmpty Syntax.SourcePath)
       Syntax.TargetPath
       Syntax.Chown
+      Syntax.Chmod
       Syntax.CopySource
       next
   | RunArgs

--- a/src/Language/Docker/Syntax/Lift.hs
+++ b/src/Language/Docker/Syntax/Lift.hs
@@ -45,6 +45,8 @@ deriveLift ''TargetPath
 
 deriveLift ''Chown
 
+deriveLift ''Chmod
+
 deriveLift ''CopySource
 
 deriveLift ''CopyArgs
@@ -78,3 +80,9 @@ deriveLift ''RunNetwork
 deriveLift ''RunFlags
 
 deriveLift ''RunArgs
+
+deriveLift ''PragmaDirective
+
+deriveLift ''EscapeChar
+
+deriveLift ''SyntaxImage

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.14
+resolver: lts-18.0
 packages:
 - .
 # Dependency packages to be pulled from upstream that are not in the resolver.
@@ -6,4 +6,4 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-- language-docker-9.0.0@sha256:2bc58e0dd7ab5e42261482a1c50ad595a81b4bd93e42c1271f45a74812ccda30,2794
+- language-docker-10.0.1@sha256:9bd912d88f82b19887cd4d926047a91a4f02883e98e4f515b218dfea2a2a2c68,3324

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,15 +5,15 @@
 
 packages:
 - completed:
-    hackage: language-docker-9.0.0@sha256:2bc58e0dd7ab5e42261482a1c50ad595a81b4bd93e42c1271f45a74812ccda30,2794
+    hackage: language-docker-10.0.1@sha256:9bd912d88f82b19887cd4d926047a91a4f02883e98e4f515b218dfea2a2a2c68,3324
     pantry-tree:
-      size: 1465
-      sha256: 53550bfa36c71764e997cdc76545256ee4cdd4f5bc5cfbf5d75be5ae2b768e2e
+      size: 2210
+      sha256: 5ba75a400271816e1b8f61e6aa085873b451a87d0012f1c8e5c7bc1b5d19913c
   original:
-    hackage: language-docker-9.0.0@sha256:2bc58e0dd7ab5e42261482a1c50ad595a81b4bd93e42c1271f45a74812ccda30,2794
+    hackage: language-docker-10.0.1@sha256:9bd912d88f82b19887cd4d926047a91a4f02883e98e4f515b218dfea2a2a2c68,3324
 snapshots:
 - completed:
-    size: 496111
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/14.yaml
-    sha256: c442d702d66b8c129b3473a32c609050aabf1dc2f8e8502402c143271a8fb141
-  original: lts-15.14
+    size: 585393
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/0.yaml
+    sha256: c632012da648385b9fa3c29f4e0afd56ead299f1c5528ee789058be410e883c0
+  original: lts-18.0


### PR DESCRIPTION
Build dockerfile-creator with language-docker 10.0.0, than occur error:

```
/path/to/dockerfile-creator/src/Language/Docker/EDSL.hs:58:45: error:
    • Couldn't match expected type ‘Syntax.AddArgs’
                  with actual type ‘Syntax.Chmod -> Syntax.AddArgs’
    • Probable cause: ‘Syntax.AddArgs’ is applied to too few arguments
      In the second argument of ‘runDef’, namely ‘(Syntax.AddArgs s d c)’
      In the expression: runDef Syntax.Add (Syntax.AddArgs s d c) n
      In an equation for ‘runD’:  
          runD (AddArgs s d c n) = runDef Syntax.Add (Syntax.AddArgs s d c) n
   |                              
58 | runD (AddArgs s d c n) = runDef Syntax.Add (Syntax.AddArgs s d c) n
   |                                             ^^^^^^^^^^^^^^^^^^^^
                                  
/path/to/dockerfile-creator/src/Language/Docker/EDSL.hs:62:49: error:
    • Couldn't match expected type ‘Syntax.CopyArgs’
                  with actual type ‘Syntax.CopySource -> Syntax.CopyArgs’
    • Probable cause: ‘Syntax.CopyArgs’ is applied to too few arguments
      In the second argument of ‘runDef’, namely
        ‘(Syntax.CopyArgs s d c f)’
      In the expression: runDef Syntax.Copy (Syntax.CopyArgs s d c f) n
      In an equation for ‘runD’:  
          runD (CopyArgs s d c f n)
            = runDef Syntax.Copy (Syntax.CopyArgs s d c f) n
   |                              
62 | runD (CopyArgs s d c f n) = runDef Syntax.Copy (Syntax.CopyArgs s d c f) n
   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^
...                                  
```

```
/path/to/dockerfile-creator/src/Language/Docker/Syntax/Lift.hs:38:1: error:
    • Could not deduce (Lift PragmaDirective)
        arising from a use of ‘lift’
      from the context: Lift args
        bound by the instance declaration
        at src/Language/Docker/Syntax/Lift.hs:38:1-24
    • In the second argument of ‘Language.Haskell.TH.Lib.Internal.appE’, namely
        ‘(lift x0_ahrM)’
      In the expression:
        (Language.Haskell.TH.Lib.Internal.appE
           (Language.Haskell.TH.Lib.Internal.conE
              ((Language.Haskell.TH.Syntax.Name
                  (Language.Haskell.TH.Syntax.mkOccName "Pragma"))
                 (((Language.Haskell.TH.Syntax.NameG
                      Language.Haskell.TH.Syntax.DataName)
                     (Language.Haskell.TH.Syntax.mkPkgName
                        "language-docker-10.0.1-E3FKNV06hZuEm7PWV7Powl"))
                    (Language.Haskell.TH.Syntax.mkModName "Language.Docker.Syntax")))))
          (lift x0_ahrM)
      In a case alternative:
          Pragma x0_ahrM
            -> (Language.Haskell.TH.Lib.Internal.appE
                  (Language.Haskell.TH.Lib.Internal.conE
                     ((Language.Haskell.TH.Syntax.Name
                         (Language.Haskell.TH.Syntax.mkOccName "Pragma"))
                        (((Language.Haskell.TH.Syntax.NameG
                             Language.Haskell.TH.Syntax.DataName)
                            (Language.Haskell.TH.Syntax.mkPkgName
                               "language-docker-10.0.1-E3FKNV06hZuEm7PWV7Powl"))
                           (Language.Haskell.TH.Syntax.mkModName "Language.Docker.Syntax")))))
                 (lift x0_ahrM)
   |        
38 | deriveLift ''Instruction
   | ^^^^^^^^^^^^^^^^^^^^^^^^
...
```

Reason for first case is https://github.com/hadolint/language-docker/pull/61 , second case is https://github.com/hadolint/language-docker/pull/62 .

This PR is fixed this errors. 